### PR TITLE
Fix: Less strict regex for superseded reference to work with PTL environments

### DIFF
--- a/nrlf_converter/nrl/constants.py
+++ b/nrlf_converter/nrl/constants.py
@@ -11,12 +11,7 @@ CUSTODIAN_ODS_REGEX = re.compile(
     "^https://directory.spineservices.nhs.uk/STU3/Organization/(?P<ods_code>\w+)$"
 )
 RELATES_TO_REPLACES_REFERENCE_REGEXES = [
-    re.compile(
-        "^https://psis-sync.national.ncrs.nhs.uk/DocumentReference/(?P<logical_id>.*)$"
-    ),
-    re.compile(
-        "^https://clinicals.spineservices.nhs.uk/DocumentReference/(?P<logical_id>.*)$"
-    ),
+    re.compile("^https://([^/]+)/DocumentReference/(?P<logical_id>.*)$")
 ]
 
 RELATES_TO_REPLACES_IDENTIFIER_REGEXES = [

--- a/nrlf_converter/nrl/tests/data/NRLF-637-replaces_reference_with_different_url.json
+++ b/nrlf_converter/nrl/tests/data/NRLF-637-replaces_reference_with_different_url.json
@@ -1,0 +1,151 @@
+{
+  "context": {
+    "period": {
+      "start": null,
+      "end": null
+    },
+    "practiceSetting": {
+      "practiceSettingCoding": [
+        {
+          "display": "Urology service",
+          "code": "310167005",
+          "system": "http://snomed.info/sct"
+        }
+      ],
+      "practiceSettingText": null
+    }
+  },
+  "meta": {
+    "versionId": "1",
+    "lastUpdated": "Tue, 13 Sep 2022 10:14:53 GMT",
+    "profile": [
+      "https://fhir.nhs.uk/STU3/StructureDefinition/NRL-DocumentReference-1"
+    ]
+  },
+  "indexed": "2022-09-13T10:14:53+00:00",
+  "content": [
+    {
+      "attachment": {
+        "creation": "2022-08-01T15:26:00+01:00",
+        "hash": "",
+        "contentType": "application/pdf",
+        "data": "",
+        "language": "",
+        "url": "https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf"
+      },
+      "format": {
+        "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+        "code": "urn:nhs-ic:unstructured",
+        "display": "Unstructured Document"
+      },
+      "extension": [
+        {
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-ContentStability-1",
+                "code": "dynamic",
+                "id": "",
+                "display": "Dynamic"
+              }
+            ]
+          },
+          "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-NRL-ContentStability-1"
+        }
+      ]
+    },
+    {
+      "extension": [
+        {
+          "url": "https://fhir.nhs.uk/STU3/StructureDefinition/Extension-NRL-ContentStability-1",
+          "valueCodeableConcept": {
+            "coding": [
+              {
+                "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-ContentStability-1",
+                "code": "dynamic",
+                "display": "Dynamic",
+                "id": ""
+              }
+            ]
+          }
+        }
+      ],
+      "attachment": {
+        "contentType": "text/html",
+        "creation": "2022-08-01T15:26:00+01:00",
+        "hash": "",
+        "url": "https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.html",
+        "data": "",
+        "language": ""
+      },
+      "format": {
+        "display": "Contact details (HTTP Unsecured)",
+        "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+        "code": "urn:nhs-ic:record-contact"
+      }
+    }
+  ],
+  "stability": {
+    "coding": [
+      {
+        "display": "Dynamic",
+        "id": "",
+        "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-ContentStability-1",
+        "code": "dynamic"
+      }
+    ],
+    "text": null
+  },
+  "attachment": {
+    "title": null,
+    "creation": "2022-08-01T15:26:00+01:00",
+    "contentType": "application/pdf",
+    "url": "https://spine-proxy.national.ncrs.nhs.uk/p1.nhs.uk/MentalhealthCarePlanReportRGD.pdf"
+  },
+  "removed": false,
+  "created": null,
+  "lastModified": "Tue, 13 Sep 2022 10:14:53 GMT",
+  "custodian": {
+    "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/RQI"
+  },
+  "class": {
+    "coding": [
+      {
+        "code": "734163000",
+        "system": "http://snomed.info/sct",
+        "display": "Care plan"
+      }
+    ],
+    "text": null
+  },
+  "logicalIdentifier": {
+    "logicalId": "e8a6fec7-334c-11ed-bd8d-000c290de2c0-58504e523530384b5851"
+  },
+  "status": "current",
+  "type": {
+    "code": "736253002",
+    "display": "Mental health crisis plan"
+  },
+  "format": {
+    "display": "Unstructured Document",
+    "system": "https://fhir.nhs.uk/STU3/CodeSystem/NRL-FormatCode-1",
+    "code": "urn:nhs-ic:unstructured"
+  },
+  "relatesTo": {
+    "code": "replaces",
+    "target": {
+      "reference": "https://we-dont-care-about-this-url-part.com/DocumentReference/e87816c5-1fc9-11ed-bd8d-000c290de2c0-58504e523530384b5851",
+      "identifier": {
+        "value": null,
+        "system": null
+      }
+    }
+  },
+  "masterIdentifier": {
+    "system": "",
+    "value": ""
+  },
+  "author": {
+    "reference": "https://directory.spineservices.nhs.uk/STU3/Organization/TESTV349"
+  }
+}

--- a/nrlf_converter/nrl/tests/test_document_pointer.py
+++ b/nrlf_converter/nrl/tests/test_document_pointer.py
@@ -4,7 +4,15 @@ from pathlib import Path
 
 import hypothesis
 import pytest
-from hypothesis.strategies import builds, data, datetimes, just, lists, text
+from hypothesis.strategies import (
+    builds,
+    data,
+    datetimes,
+    just,
+    lists,
+    sampled_from,
+    text,
+)
 
 from nrlf_converter import BadRelatesTo, CustodianError, ValidationError
 from nrlf_converter.nrl.constants import SSP, UPDATE_DATE_FORMAT
@@ -140,8 +148,19 @@ def test_ods_code_raises_custodian_error(document_pointer: DocumentPointer):
         code=just("replaces"),
         target=builds(
             Reference,
-            reference=just(
-                "https://psis-sync.national.ncrs.nhs.uk/DocumentReference/THE_LOGICAL_ID"
+            reference=sampled_from(
+                [
+                    # Live:
+                    "https://psis-sync.national.ncrs.nhs.uk/DocumentReference/THE_LOGICAL_ID",
+                    "https://clinicals.spineservices.nhs.uk/DocumentReference/THE_LOGICAL_ID",
+                    # Ref:
+                    "https://psis-sync.refnational.ncrs.nhs.uk/DocumentReference/THE_LOGICAL_ID",
+                    "https://clinicals.refspineservices.nhs.uk/DocumentReference/THE_LOGICAL_ID",
+                    # INT:
+                    "https://msg.int.spine2.ncrs.nhs.uk/DocumentReference/THE_LOGICAL_ID",
+                    # Any url, but conforming to the structure:
+                    "https://it-could-be-any-url.com/DocumentReference/THE_LOGICAL_ID",
+                ]
             ),
             identifier=just(None),
         ),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nrlf-converter"
-version = "0.0.8"
+version = "0.0.9"
 description = "NHS Clinicals Record Locator Document Pointer to HL7 FHIR R4 DocumentReference conversion"
 authors = ["NHSDigital"]
 license = "MIT"


### PR DESCRIPTION
NRLF-637.

In order to ensure that the INT environment is working properly.
We need to adjust the convertor rules